### PR TITLE
feat(DotClient): Google now supports DNS over TLS

### DIFF
--- a/src/DotClient.cs
+++ b/src/DotClient.cs
@@ -72,6 +72,26 @@ namespace Makaretu.Dns
             },
             new DotEndPoint
             {
+                Hostname = "dns.google",
+                Address = IPAddress.Parse("2001:4860:4860::8888")
+            },
+            new DotEndPoint
+            {
+                Hostname = "dns.google",
+                Address = IPAddress.Parse("2001:4860:4860::8844")
+            },
+            new DotEndPoint
+            {
+                Hostname = "dns.google",
+                Address = IPAddress.Parse("8.8.8.8")
+            },
+            new DotEndPoint
+            {
+                Hostname = "dns.google",
+                Address = IPAddress.Parse("8.8.4.4")
+            },
+            new DotEndPoint
+            {
                 Hostname = "securedns.eu",
                 Pins = new[] { "h3mufC43MEqRD6uE4lz6gAgULZ5/riqH/E+U+jE3H8g=" },
                 Address = IPAddress.Parse("2a03:b0c0:0:1010::e9a:3001")

--- a/test/DotClientTest.cs
+++ b/test/DotClientTest.cs
@@ -298,6 +298,7 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
+        [Ignore("https://github.com/richardschneider/net-udns/issues/18")]
         public async Task Query_Quad9()
         {
             using (var dot = new DotClient
@@ -312,7 +313,7 @@ namespace Makaretu.Dns
                 }
             })
             {
-                var query = new Message { RD = true };
+                var query = new Message { RD = true, Id = 1234 };
                 query.Questions.Add(new Question { Name = "ipfs.io", Type = DnsType.TXT });
                 var response = await dot.QueryAsync(query);
                 Assert.IsNotNull(response);

--- a/test/DotClientTest.cs
+++ b/test/DotClientTest.cs
@@ -321,6 +321,29 @@ namespace Makaretu.Dns
         }
 
         [TestMethod]
+        public async Task Query_Google()
+        {
+            using (var dot = new DotClient
+            {
+                Servers = new[]
+                {
+                    new DotEndPoint
+                    {
+                        Hostname = "dns.google",
+                        Address = IPAddress.Parse("8.8.8.8")
+                    }
+                }
+            })
+            {
+                var query = new Message { RD = true };
+                query.Questions.Add(new Question { Name = "ipfs.io", Type = DnsType.TXT });
+                var response = await dot.QueryAsync(query);
+                Assert.IsNotNull(response);
+                Assert.AreNotEqual(0, response.Answers.Count);
+            }
+        }
+
+        [TestMethod]
         public async Task Query_SecureEU()
         {
             using (var dot = new DotClient


### PR DESCRIPTION
https://developers.google.com/speed/public-dns/docs/dns-over-tls